### PR TITLE
Stability in case of training restart

### DIFF
--- a/src/finetuning_scheduler/fts.py
+++ b/src/finetuning_scheduler/fts.py
@@ -576,6 +576,8 @@ class FinetuningScheduler(ScheduleImplMixin, ScheduleParsingMixin, CallbackDepMi
         if self.curr_depth == 0:
             assert isinstance(self.ft_schedule, Dict)
             self._validate_opt_init()
+        trainer.optimizers[0].param_groups.clear()
+        trainer.optimizers[0].state.clear()
         super().on_fit_start(trainer, pl_module)
 
     def state_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
## What does this PR do?

In case people construct their models (as happens for example [here](https://github.com/unit8co/darts/blob/33d8a33e03e2cba61f7eb0dce2081b7b0ef79319/darts/models/forecasting/pl_forecasting_module.py#L301) in Darts) with including _all_ parameters instead of _just the ones requiring gradients_, up till now the finetuner was getting in trouble. 
Also when a finetuning run is not initialized in the first epoch, some trouble could ensue.

In it's current form the PR changes only the behavior in case of the first finetuning epoch in two ways:
- memorizes the epoch number as "first"
- re-initializes the optimizer to be able to ensure, that _only_ the right parameters are thawed.

In it's current form it makes the finetuner compatible with Darts.