### PR TITLE
Allow for setting separate `log_dir`

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,7 +100,7 @@ thawed/unfrozen parameter groups associated with each fine-tuning phase as desir
 and executed in ascending order. In addition to being zero-indexed, fine-tuning phase keys should be contiguous and
 either integers or convertible to integers via ``int()``.
 
-1. First, generate the default schedule to ``Trainer.log_dir``. It will be named after your
+1. First, generate the default schedule to the specified ``log_dir`` (defaults to ``Trainer.log_dir``). It will be named after your
    :external+pl:class:`~lightning.pytorch.core.module.LightningModule` subclass with the suffix
    ``_ft_schedule.yaml``.
 


### PR DESCRIPTION
## What does this PR do?

Allows for setting a separate `log_dir` from the trainer `log_dir`. 

Fixes #16

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/speediedan/finetuning-scheduler/blob/main/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/speediedan/finetuning-scheduler/blob/main/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
