### PR TITLE
fix ReduceLROnPlateau import from pytorch-lightning

### DIFF
--- a/src/finetuning_scheduler/strategy_adapters/base.py
+++ b/src/finetuning_scheduler/strategy_adapters/base.py
@@ -22,8 +22,8 @@ from typing import Callable, List, Optional, Tuple, Dict
 
 import torch
 
+from torch.optim.lr_scheduler import ReduceLROnPlateau
 from lightning.fabric.utilities import rank_zero_info, rank_zero_warn
-from lightning.fabric.utilities.types import ReduceLROnPlateau
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.callbacks import BaseFinetuning


### PR DESCRIPTION
## What does this PR do?

With [the latest pytorch-lightning 2.5.6](https://github.com/Lightning-AI/pytorch-lightning/releases/tag/2.5.6), `ReduceLROnPlateau` cannot be imported from `lightning.fabric.utilities.types`.
Relevant change upstream: https://github.com/Lightning-AI/pytorch-lightning/compare/2.5.5...2.5.6#diff-3c91827ebfece21205d023a4f9b5e1d968ec5b0433b55afdf56810feac32ce30L31

This PR directly imports it from `torch.optim.lr_scheduler`.
The behavior is unchanged.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/speediedan/finetuning-scheduler/blob/main/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/speediedan/finetuning-scheduler/blob/main/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
