### PR TITLE
Adopt self-contained step numbering in the Azure triage skill half

### DIFF
--- a/.claude/skills/az-pipelines-failure-triage/SKILL.md
+++ b/.claude/skills/az-pipelines-failure-triage/SKILL.md
@@ -15,8 +15,9 @@ FTS-specific, which is why it lives here rather than in a shared skill.
 | GPU serialization, a lease wait, a lease that looks stuck                                    | `gpu-lease` (shared, vendored)        |
 | A build that **started and failed**                                                          | this skill                            |
 
-**The steps below are numbered from 4 deliberately.** Steps 1 to 3, driving the pipeline, live in
-`az-pipelines-ops`. The pair is one sequence and the numbering is what keeps that visible.
+**This half is self-contained and its steps start at 1.** Driving the pipeline, from authorization
+through gates to dispatch, is its own procedure in `az-pipelines-ops`, also numbered from 1. Step
+numbers are local to each half; the pointers above and below are what connect them.
 
 > ⛔ **Do not diagnose a `notStarted` build here.** Start at `az-pipelines-ops` Step 1, which reads the
 > build timeline first. The approvals API cannot see a build blocked on resource authorization, so an
@@ -96,7 +97,7 @@ and fails open when the directory is absent. The mechanics are commented inline 
 **For everything else about the lease, including the hard rule that a CI-held lease is never
 force-reset, use the `gpu-lease` skill.**
 
-## Step 4: Triage the Failure Class
+## Step 1: Triage the Failure Class
 
 **Queue / approval** — the build never left `notStarted`. This is not a triage case; go to
 `az-pipelines-ops` Step 1 and read the timeline. Do not conclude anything from the approvals endpoint
@@ -121,10 +122,10 @@ sudo "$AGENT_HOME"/restart-stack.sh
 Check for orphaned processes from an interrupted standalone run before re-queuing —
 `scripts/manage_standalone_processes.sh` is the tool for reaping them.
 
-**Test failure** — reproduce locally (Step 5). Note which step failed: a `Testing: standard` failure is
+**Test failure** — reproduce locally (Step 2). Note which step failed: a `Testing: standard` failure is
 usually reproducible on any machine; a `standalone multi-gpu` or `Multi-GPU Examples` failure usually is not.
 
-## Step 5: Reproduce Locally
+## Step 2: Reproduce Locally
 
 Reproduce the pipeline's exact environment by running the same image. Full walkthrough in the private
 `fts_azure_pipeline_local.md`; the essentials:
@@ -173,7 +174,7 @@ bash ./tests/special_tests.sh --mark_type=standalone --filter_pattern='test_f'
 sed -i 's/set -e/set +e/g' ./tests/special_tests.sh   # revert before committing
 ```
 
-## Step 6: Narrowing Multi-GPU Failures
+## Step 3: Narrowing Multi-GPU Failures
 
 FTS's heavy GPU surface is FSDP and model-parallel, and both assert against recorded expected states in
 `tests/fsdp_expected_paths.py` and `tests/model_parallel_expected_paths.py`. When one of those fails:


### PR DESCRIPTION
## What does this PR do?

Conforms this repo to the house convention agreed across the three repos that carry a split of the Azure pipeline skill: **each half numbers its own steps from 1.** This half's Steps 4, 5, 6 become 1, 2, 3.

When #36 split the skill, I kept the retained steps numbered from 4 so the two halves would read as one sequence. That was a judgment call, and the convention went the other way for a better reason than either of my arguments: readers skim directly into a section rather than reading top-down, so a half opening at "Step 4" is met by someone who never saw the note explaining why. The competing risk, that two skills both starting at Step 1 read as rival procedures rather than halves, is mitigated by the reciprocal pointers, which are content a skimmer actually lands on. Given a risk addressed by content and a risk addressed by the reader's route, take the former.

The explicit pointer block introduced here in #36 is being adopted in all three repos alongside this numbering, so the outcome is the pointer plus self-contained numbering everywhere.

**Deliberately unchanged:** the four references to `az-pipelines-ops` Step 1 and Step 2. Those name the *other* half's numbering and remain correct. The header now states the disambiguation rule: a bare "Step N" is local, a qualified "`az-pipelines-ops` Step N" is remote.

### Does your PR introduce any breaking changes? If yes, please list them.

None. One `.md` file under `.claude/`; no source, test, or packaging file is touched.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs) — maintainer-directed, follows #36
- [x] Did you read the [contributor guideline](https://github.com/speediedan/finetuning-scheduler/blob/main/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs) — n/a; the skill's evals carry no step references
- [x] Did you verify new and **existing tests pass** locally with your changes? — `pre-commit` clean; `sync-shared-skills.sh status` reports both vendored skills in sync, exit 0
- [x] Did you list all the **breaking changes** introduced by this pull request? — none
- [ ] Did you **update the [CHANGELOG](https://github.com/speediedan/finetuning-scheduler/blob/main/CHANGELOG.md)**? — not applicable; the changelog tracks the package and this has no user-visible effect

https://claude.ai/code/session_0148maaNP8huF1eSUq9RCErP