### PR TITLE
Resync az-pipelines-ops and restore the bulk-approval guard the shared half cannot carry

### DIFF
--- a/.claude/skills/az-pipelines-failure-triage/SKILL.md
+++ b/.claude/skills/az-pipelines-failure-triage/SKILL.md
@@ -47,6 +47,8 @@ numbers are local to each half; the pointers above and below are what connect th
 - Approvals can be driven with the shared
   `project_admin/shared_admin_scripts/az_pipeline_agent_scripts/manage-approvals.sh` in the private admin
   repo (`-o speediedan -p finetuning-scheduler`), or with the REST calls in `az-pipelines-ops` Step 2.
+  **Identify each gate before releasing it**, per that step. The script's `-m reject-all` and any
+  approve loop act on the whole project's pending set, which is not scoped to your work.
 - Runner: a self-hosted agent on a GPU host, running rootless Docker on cgroups v2. The systemd unit sets
   `OOMScoreAdjust=-900`; it does **not** set `MemoryMax`/`MemoryHigh` (an earlier version of this file
   claimed it did — verified absent 2026-07-29, no drop-in exists).
@@ -194,6 +196,11 @@ FTS's heavy GPU surface is FSDP and model-parallel, and both assert against reco
 - Don't re-queue a build to "see if it passes" before checking the agent log — if the agent is wedged,
   every re-queue burns a 100-minute timeout slot on a pool interpretune also needs.
 - Don't restart the agent on the strength of an empty approvals response. See the warning at the top.
+- Don't approve or dispose of pending gates in bulk. `manage-approvals.sh -m reject-all`, and the
+  obvious approve-everything loop, act on every gate in the project, not just yours. On this host an
+  approval is often held deliberately while someone waits for the GPU lease to free, because approving
+  dispatches a heavy job immediately, so releasing another project's gate waives a precondition
+  protecting the host rather than just that run. List and identify first: `az-pipelines-ops` Step 2.
 - Don't edit expected-path modules to make a test green without establishing which side actually changed.
 - Don't commit the `set +e` patch to `special_tests.sh`.
 

--- a/.claude/skills/az-pipelines-ops/SKILL.md
+++ b/.claude/skills/az-pipelines-ops/SKILL.md
@@ -13,6 +13,16 @@ before diagnosing a red build, because the failure taxonomy is repo-specific and
 GPU serialization is a separate concern with its own skill. If this host uses a lease, see `gpu-lease`
 rather than anything here.
 
+**Most of what goes wrong here is order, not ignorance.** Each step below is a correct action that
+produces a wrong answer when taken before the one that scopes it: querying approvals before reading
+the timeline, or approving a gate before identifying which build it belongs to. Both were real
+incidents. Treat the sequence as the content.
+
+**Step references:** a bare "Step N" means a step in THIS skill. A reference to a step in a
+repository's own companion skill is always qualified by that skill's name. Where a skill is split into
+a shared half and a repo-local half, both halves number from 1, so an unqualified number is ambiguous
+unless this rule is followed.
+
 ## When to use this skill
 
 - A build stays `notStarted` after a pull request becomes ready for review.
@@ -61,12 +71,33 @@ exactly what it wants.
 
 ## Step 2: Release or reject a gated run
 
-Once the timeline shows `Checkpoint.Approval` pending, the approvals API becomes the right tool:
+Once the timeline shows `Checkpoint.Approval` pending, the approvals API becomes the right tool. But
+**identify each gate before releasing it.**
+
+**A pending-approvals query is not scoped to your work.** Approvals are per PROJECT, and several
+pipelines commonly share one project, so the result set includes gates belonging to other people and
+other repositories. The obvious loop, `for id in $(...); do approve $id; done`, releases all of them.
+That has happened, twice, and neither instance caused harm by design.
+
+It matters beyond tidiness because an approval is often held deliberately. On a shared host the person
+holding it may be waiting for a GPU lease to free or for the machine to go quiet, since approving
+dispatches a heavy job immediately. That precondition protects the HOST, not just their run, so
+releasing their gate bypasses a safety check that was never yours to waive.
+
+The payload carries the build id under `$expand=steps`, so identification is cheap:
 
 ```bash
 curl -sS -u ":${AZ_PAT}" \
-  "${ORG}/${PROJECT}/_apis/pipelines/approvals?state=pending&api-version=7.1-preview.1"
+  "${ORG}/${PROJECT}/_apis/pipelines/approvals?state=pending&\$expand=steps&api-version=7.1-preview.1"
+# value[].pipeline.owner._links.web.href ends in buildId=<n>
 
+az pipelines build show --id <n> --organization "${ORG}" --project "${PROJECT}" \
+  --query "{def:definition.name,branch:sourceBranch}"
+```
+
+Then release only the gates you identified as yours:
+
+```bash
 curl -sS -X PATCH -u ":${AZ_PAT}" -H "Content-Type: application/json" \
   -d '[{"approvalId":"<id>","status":"approved","comment":"<why>"}]' \
   "${ORG}/${PROJECT}/_apis/pipelines/approvals?api-version=7.1-preview.1"


### PR DESCRIPTION
## What does this PR do?

**Resyncs the vendored `az-pipelines-ops`** with its public master, which gained two things: identify-then-release in Step 2, and the step-reference qualification rule in its preamble (a bare "Step N" is local, cross-skill references are qualified by skill name).

**Restores a warning I dropped in #36 and should not have.** The pre-split skill said:

> Don't approve stale pending gates in bulk without listing them first; `reject-all` disposes of real pending runs too.

I removed it during the reduction as operational, assuming the shared half would carry it. It cannot. The hazard is concrete in `manage-approvals.sh -m reject-all`, and a repo-neutral master cannot name a script living in a private admin repo. So the reduction dropped a warning with nowhere else to live, which is exactly the failure the "per-repo facts move to the local half" contract exists to prevent, and I introduced it while applying that contract.

It matters more after the split than before. Pending approvals are scoped to the **project**, not to your work, so a bulk release takes other people's gates; that happened twice this week in the sibling project sharing this org. And on this host an approval is often held deliberately while someone waits for the GPU lease to free, since approving dispatches a heavy job immediately. Releasing another project's gate therefore waives a precondition protecting the **host**, not just that run.

The guard is in What Not to Do, and the `manage-approvals.sh` pointer in Constraints now carries identify-first inline, so a reader who reaches the script there meets it without needing to reach the bottom of the file.

### Does your PR introduce any breaking changes? If yes, please list them.

None. Two `.md` files under `.claude/`; no source, test, or packaging file is touched.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs) — maintainer-directed, follows #36 and #37
- [x] Did you read the [contributor guideline](https://github.com/speediedan/finetuning-scheduler/blob/main/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together? — the resync and the restored guard are the same concern: what the shared half can and cannot carry
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs) — n/a, no source change
- [x] Did you verify new and **existing tests pass** locally with your changes? — `pre-commit` clean; `sync-shared-skills.sh status` reports both vendored skills in sync, exit 0; cross-half restart gate and all four qualified cross-skill references re-verified after the edit
- [x] Did you list all the **breaking changes** introduced by this pull request? — none
- [ ] Did you **update the [CHANGELOG](https://github.com/speediedan/finetuning-scheduler/blob/main/CHANGELOG.md)**? — not applicable; the changelog tracks the package and this has no user-visible effect

https://claude.ai/code/session_0148maaNP8huF1eSUq9RCErP