### PR TITLE
Resync az-pipelines-ops and record that this pipeline already carries the workspace cleanup

### DIFF
--- a/.claude/skills/az-pipelines-failure-triage/SKILL.md
+++ b/.claude/skills/az-pipelines-failure-triage/SKILL.md
@@ -68,6 +68,11 @@ numbers are local to each half; the pointers above and below are what connect th
 - Container image `speediedan/finetuning-scheduler:py3.13-pt2.14.0-pl2.6-azpl-init`, in-container venv
   `/tmp/venvs/fts_dev`, `--gpus all --shm-size=512m`.
 - Only `CODECOV_TOKEN` is mapped. There are no HuggingFace or gated-model secrets in this pipeline.
+- The workspace-ownership cleanup described in `az-pipelines-ops` is **already present here**: the
+  `Cleaning up agent workspace` step (`condition: always()`) chmods `/__w/1/s` and clears
+  `.pytest_cache` from inside the container. Do not remove or "simplify" it. Without it a green run
+  arms a `Checkout` failure that blocks every later build on this definition and needs root on the
+  agent host to clear.
 
 ### The step split
 

--- a/.claude/skills/az-pipelines-ops/SKILL.md
+++ b/.claude/skills/az-pipelines-ops/SKILL.md
@@ -153,8 +153,56 @@ curl -sS -u ":${AZ_PAT}" "${ORG}/${PROJECT}/_apis/build/builds/<id>?api-version=
   "the build succeeded" is not evidence that each phase did. Verify at task level when a specific phase
   is the one you care about.
 
+## A build that fails at `Checkout` in seconds, and then every build after it
+
+Distinct from the three `notStarted` causes above, because this build DID dispatch. It fails in the
+checkout task, before any step of the pipeline runs, on a path the previous run left behind:
+
+```
+System.UnauthorizedAccessException: Access to the path '.../s/.pytest_cache/v/cache/nodeids' is denied
+warning: Unable to run "git clean -ffdx" and "git reset --hard HEAD" successfully,
+         delete source folder instead
+```
+
+**Mechanism.** A containerised job under rootless docker with userns remapping writes into the mapped
+workspace as the container's host **subuid**, not as the agent's uid. The agent begins the next build
+with `git clean -ffdx` and `git reset --hard` **as itself**, cannot remove those files, and falls back
+to deleting the source folder, which fails the same way.
+
+**It is self-perpetuating, and that is the part that surprises people.** Every later build on that
+definition fails identically, and none can fix it, because the cleanup would have to run inside a build
+that cannot start. A GREEN run is what creates the condition, so the failure appears immediately after
+a success and looks unrelated to it.
+
+Two things are needed and they are not interchangeable:
+
+1. **Clear the existing leftover once, with host privileges.** Only someone who can act as root on the
+   agent host can remove files owned by a container subuid. Nothing inside a pipeline can do it, and no
+   amount of re-running helps.
+
+1. **Stop it recurring**, with a step that runs INSIDE the container, where that uid still owns what it
+   wrote, under `condition: always()` so a failed run cleans up too:
+
+   ```yaml
+   - bash: |
+       sudo chmod -R 775 <workspace sources dir> || true
+       sudo rm -rf <workspace sources dir>/.pytest_cache || true
+     displayName: "Normalize workspace ownership"
+     condition: always()
+   ```
+
+   The sources dir is the agent's per-definition work path and differs by definition, so take it from
+   the job rather than hardcoding one repo's. `.pytest_cache` is the usual culprit; the `chmod` covers
+   whatever else a run leaves behind.
+
+**Any containerised job on a self-hosted agent wants step 2 from the day it is written.** Adding it
+after the first occurrence still needs a privileged human to clear the backlog first.
+
 ## What not to do
 
+- **Do not omit the workspace-ownership cleanup from a new containerised job.** It costs four lines up
+  front. Without it the first green run arms a failure that blocks every later build on that definition
+  and can only be cleared by someone with root on the agent host.
 - **Do not restart the agent to clear a stuck build** until the timeline has ruled out approval and
   authorization. Restarting strands the run without fixing a permission. Once the timeline shows no
   checkpoint records, a genuinely wedged agent IS the remaining cause and restarting it is correct;


### PR DESCRIPTION
## What does this PR do?

**Resyncs the vendored `az-pipelines-ops`**, which gained a section on a failure mode worth knowing about: a containerised job under rootless docker with userns remapping writes into the mapped workspace as the container's host subuid. The agent starts the next build with `git clean -ffdx` and `git reset --hard` as itself, cannot remove those files, and falls back to deleting the source folder, which fails the same way. The build dies at `Checkout` in seconds, before any step runs, and every later build on that definition fails identically.

It is self-perpetuating, because the cleanup would have to run inside a build that cannot start, and a **green** run is what arms it, so the failure appears right after a success and looks unrelated.

**This pipeline was already protected.** `gpu-tests.yml`'s `Cleaning up agent workspace` step chmods `/__w/1/s` and clears `.pytest_cache` from inside the container under `condition: always()`, which is exactly the preventive half the shared section prescribes.

That was recorded only as a YAML comment. The knowledge existed as configuration and not as explanation, which is the shape that gets removed by someone tidying a step whose purpose is not written down. So Constraints in the triage half now records that the step exists, where it lives, and not to remove it. The shared half cannot carry that: it prescribes taking the sources dir from the job rather than hardcoding one repo's, and `/__w/1/s` is ours.

### Does your PR introduce any breaking changes? If yes, please list them.

None. Two `.md` files under `.claude/`; no source, test, or packaging file is touched.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs) — maintainer-directed, follows #36, #37, #38
- [x] Did you read the [contributor guideline](https://github.com/speediedan/finetuning-scheduler/blob/main/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together? — the resync and the Constraints line are the same concern: what the shared half prescribes and what only this repo can state
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs) — n/a, no source change
- [x] Did you verify new and **existing tests pass** locally with your changes? — `pre-commit` clean and a no-op on the vendored file; `sync-shared-skills.sh status` in sync at exit 0; the vendored copy verified byte-identical to the published master *after* the hook ran; cross-half restart gate and all six qualified cross-skill references re-verified
- [x] Did you list all the **breaking changes** introduced by this pull request? — none
- [ ] Did you **update the [CHANGELOG](https://github.com/speediedan/finetuning-scheduler/blob/main/CHANGELOG.md)**? — not applicable; the changelog tracks the package and this has no user-visible effect

https://claude.ai/code/session_0148maaNP8huF1eSUq9RCErP