### PR TITLE
Resync az-pipelines-ops: run the fix branch first after a manual clear

### DIFF
--- a/.claude/skills/az-pipelines-ops/SKILL.md
+++ b/.claude/skills/az-pipelines-ops/SKILL.md
@@ -174,6 +174,13 @@ definition fails identically, and none can fix it, because the cleanup would hav
 that cannot start. A GREEN run is what creates the condition, so the failure appears immediately after
 a success and looks unrelated to it.
 
+**After a manual clear, the FIRST build you run must carry the prevention step.** This is the trap,
+and the natural instinct is the wrong order: revalidating the default branch first feels like the safe
+confirmation, and if that branch does not yet contain the cleanup step, a green run re-arms the
+failure and recreates by hand exactly what was just cleared by hand. Approve the branch carrying the
+fix first, precisely because it is the one that cleans up after itself. Only once the fix is on the
+default branch is revalidating it safe.
+
 Two things are needed and they are not interchangeable:
 
 1. **Clear the existing leftover once, with host privileges.** Only someone who can act as root on the


### PR DESCRIPTION
## What does this PR do?

Resyncs the vendored `az-pipelines-ops`, which gained the ordering trap that follows the workspace-ownership failure landed in #39.

After someone with root on the agent host clears the leftover files by hand, **the first build run must be one that carries the prevention step.** The instinct is the wrong order: revalidating the default branch feels like the safe confirmation, but if that branch does not yet contain the cleanup step, a green run re-arms the failure and recreates by hand exactly what was just cleared by hand.

**Not currently live for this repo.** `gpu-tests.yml` has carried the cleanup on the default branch for some time, so revalidating it here is safe. Vendored anyway, because the trap applies to any future definition added before its own cleanup step, and because the copy is held byte-identical by contract rather than by relevance.

### Does your PR introduce any breaking changes? If yes, please list them.

None. One vendored `.md` under `.claude/`; no source, test, or packaging file is touched.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs) — maintainer-directed, follows #39
- [x] Did you read the [contributor guideline](https://github.com/speediedan/finetuning-scheduler/blob/main/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs) — n/a, no source change
- [x] Did you verify new and **existing tests pass** locally with your changes? — `pre-commit` clean and a no-op on the vendored file; verified byte-identical to the published master *after* the hook ran; upstream neutrality gate passes on the vendored copy; `sync-shared-skills.sh status` in sync at exit 0
- [x] Did you list all the **breaking changes** introduced by this pull request? — none
- [ ] Did you **update the [CHANGELOG](https://github.com/speediedan/finetuning-scheduler/blob/main/CHANGELOG.md)**? — not applicable; the changelog tracks the package and this has no user-visible effect

https://claude.ai/code/session_0148maaNP8huF1eSUq9RCErP